### PR TITLE
Update addredirect.py to populate destination_host field

### DIFF
--- a/addredirect.py
+++ b/addredirect.py
@@ -130,7 +130,7 @@ def generate_redirect_entry(origin_site_metadata: dict, destination_site_metadat
     # Generate tags
     wikifarm = destination_site_metadata.get("wikifarm")
     if wikifarm is not None:
-        entry["tags"] = [wikifarm]
+        entry["destination_host"] = wikifarm
 
     return entry
 

--- a/utils.py
+++ b/utils.py
@@ -176,12 +176,18 @@ def detect_wikifarm(url_list: Iterable[str]) -> Optional[str]:
     :return: Name of the site's wikifarm, if it is hosted by one
     """
     # This is only relevant for destinations, so "fandom" is not checked for (and it would likely give false positives)
-    known_wikifarms = {"shoutwiki", "wiki.gg", "miraheze", "wikitide"}
+    known_wikifarms = [
+        { "name": "ShoutWiki", "url": "shoutwiki.com" },
+        { "name": "wiki.gg", "url": "wiki.gg" },
+        { "name": "Miraheze", "url": "miraheze.org" },
+        { "name": "WikiTide", "url": "wikitide.org" },
+        { "name": "Paradox", "url": "paradoxwikis.com" }
+    ]
 
     for wikifarm in known_wikifarms:
         for url in url_list:
-            if wikifarm in url:
-                return wikifarm
+            if wikifarm["url"] in url:
+                return wikifarm["name"]
     return None
 
 


### PR DESCRIPTION
With IWB [PR #737](https://github.com/KevinPayravi/indie-wiki-buddy/pull/737), we started storing the destination host in a dedicated `destiantion_host` field, instead of in the `tags` array.

This PR: 
* Updates `addredirect.py` to populate the `destiantion_host` field.
* Adds Paradox as a known wikifarm.
* Updates the `detect_wikifarm` function to check for a wikifarm via URL, instead of just the name (e.g. check for paradoxwikis.com instead of paradox).