### PR TITLE
Error handling for favicons

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -241,10 +241,11 @@ def download_wiki_icon(icon_url: str, icon_filename: str, language_code: str,
     try:
         icon_url = normalize_url_protocol(icon_url)
         icon_file_response = session.get(icon_url, **kwargs)
+        if not icon_file_response.ok:
+            print(f"⚠ Failed to download icon from {icon_url} (HTTP {icon_file_response.status_code})")
+            return None
     except ConnectionError:
-        icon_file_response = None
-
-    if not icon_file_response:
+        print(f"⚠ Connection error while downloading icon from {icon_url}")
         return None
 
     # Determine filepath
@@ -255,9 +256,13 @@ def download_wiki_icon(icon_url: str, icon_filename: str, language_code: str,
     icon_filepath = os.path.join(icon_folderpath, icon_filename)
 
     # Write to file
-    image_file = Image.open(BytesIO(icon_file_response.content))
-    image_file = image_file.resize((16, 16))
-    image_file.save(icon_filepath, optimize=True)  # PIL ensures that conversion from ICO to PNG is safe
+    try:
+        image_file = Image.open(BytesIO(icon_file_response.content))
+        image_file = image_file.resize((16, 16))
+        image_file.save(icon_filepath, optimize=True)  # PIL ensures that conversion from ICO to PNG is safe
+    except Exception as e:
+        print(f"⚠ Failed to process icon from {icon_url}: {str(e)}")
+        return None
 
     return icon_filename
 


### PR DESCRIPTION
For some wikis, even if there is a favicon, fetching the favicon can error out (for reasons currently unknown to me):

```
🕑 Grabbing destination wiki's favicon...
Traceback (most recent call last):
  File "/Users/kayvan/Development/temp/indie-wiki-buddy-scripts/addredirect.py", line 621, in <module>
    main()
  File "/Users/kayvan/Development/temp/indie-wiki-buddy-scripts/addredirect.py", line 595, in main
    icon_filename = download_wiki_icon(icon_url, icon_filename, language, iwb_filepath=iwb_filepath,
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kayvan/Development/temp/indie-wiki-buddy-scripts/utils.py", line 264, in download_wiki_icon
    image_file = Image.open(BytesIO(icon_file_response.content))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kayvan/Development/venv/lib/python3.12/site-packages/PIL/Image.py", line 3498, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x113c3b790>
```

This PR adds some error handling so the script can continue.